### PR TITLE
rename set_instance to load_instance

### DIFF
--- a/app/controllers/stirling/base_controller.rb
+++ b/app/controllers/stirling/base_controller.rb
@@ -1,7 +1,7 @@
 class Stirling::BaseController < ApplicationController
   before_filter :build_instance, only: [:new, :create]
-  before_filter :set_instance, only: [:show, :destroy, :edit, :update]
-  before_filter :set_instances, only: [:index]
+  before_filter :load_instance, only: [:show, :destroy, :edit, :update]
+  before_filter :load_instances, only: [:index]
   before_filter :assign_params, only: [:update]
 
   def index; end
@@ -13,7 +13,7 @@ class Stirling::BaseController < ApplicationController
   def destroy; end
 
   private
-  def set_instances
+  def load_instances
     instances = if Stirling::Gem.load? "ransack"
       @q = model.search params[:q]
       @q.result
@@ -28,7 +28,7 @@ class Stirling::BaseController < ApplicationController
     instance_variable_set "@#{model_name.pluralize}", instances
   end
 
-  def set_instance
+  def load_instance
     self.instance = model.find params[:id]
   end
 

--- a/spec/controllers/stirling/base_controller_spec.rb
+++ b/spec/controllers/stirling/base_controller_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Stirling::BaseController, :type => :controller do
     it {is_expected.to eq :"#{model_name}"}
   end
 
-  describe "#set_instance" do
-    subject {controller.send :set_instance}
+  describe "#load_instance" do
+    subject {controller.send :load_instance}
 
     before do
       expect(controller.send(:model)).to receive(:find).and_return instance
@@ -127,8 +127,8 @@ RSpec.describe Stirling::BaseController, :type => :controller do
     end
   end
 
-  describe "#set_instances" do
-    subject {controller.send :set_instances}
+  describe "#load_instances" do
+    subject {controller.send :load_instances}
 
     context "when app includes ransack" do
       let(:ransack){double "ransack", :result => nil}


### PR DESCRIPTION
##### `set_instance` -> `load_instance`
`set_instance` is a confusing name because it couldn't be understood whether it loads a resource or not. It must be named with a more explicit name.